### PR TITLE
Address review feedback on fee-update restart fix

### DIFF
--- a/channeldb/channel.go
+++ b/channeldb/channel.go
@@ -3420,17 +3420,35 @@ func (c *OpenChannel) AdvanceCommitChainTail(fwdPkg *FwdPkg,
 			return err
 		}
 
+		// Persist the local updates the peer hasn't yet signed so they
+		// can be restored after restart.
+		var b2 bytes.Buffer
+		err = serializeLogUpdates(&b2, updates)
+		if err != nil {
+			return err
+		}
+
+		err = chanBucket.Put(remoteUnsignedLocalUpdatesKey, b2.Bytes())
+		if err != nil {
+			return fmt.Errorf("unable to restore remote unsigned "+
+				"local updates: %v", err)
+		}
+
 		// Persist the unsigned acked updates that are not included
 		// in their new commitment.
 		updateBytes := chanBucket.Get(unsignedAckedUpdatesKey)
+		if updateBytes == nil {
+			// This shouldn't normally happen as we always store
+			// the number of updates, but could still be
+			// encountered by nodes that are upgrading.
+			newRemoteCommit = &newCommit.Commitment
+			return nil
+		}
 
-		var unsignedUpdates []LogUpdate
-		if updateBytes != nil {
-			r := bytes.NewReader(updateBytes)
-			unsignedUpdates, err = deserializeLogUpdates(r)
-			if err != nil {
-				return err
-			}
+		r := bytes.NewReader(updateBytes)
+		unsignedUpdates, err := deserializeLogUpdates(r)
+		if err != nil {
+			return err
 		}
 
 		var validUpdates []LogUpdate
@@ -3455,20 +3473,6 @@ func (c *OpenChannel) AdvanceCommitChainTail(fwdPkg *FwdPkg,
 		if err != nil {
 			return fmt.Errorf("unable to store under "+
 				"unsignedAckedUpdatesKey: %w", err)
-		}
-
-		// Persist the local updates the peer hasn't yet signed so they
-		// can be restored after restart.
-		var b2 bytes.Buffer
-		err = serializeLogUpdates(&b2, updates)
-		if err != nil {
-			return err
-		}
-
-		err = chanBucket.Put(remoteUnsignedLocalUpdatesKey, b2.Bytes())
-		if err != nil {
-			return fmt.Errorf("unable to restore remote unsigned "+
-				"local updates: %v", err)
 		}
 
 		newRemoteCommit = &newCommit.Commitment

--- a/channeldb/channel_test.go
+++ b/channeldb/channel_test.go
@@ -978,6 +978,108 @@ func TestChannelStateTransition(t *testing.T) {
 	require.Empty(t, fwdPkgs, "no forwarding packages should exist")
 }
 
+func TestAdvanceCommitChainTailRemoteUnsignedLocalUpdatesWithoutUnsignedAckedKey(
+	t *testing.T) {
+
+	t.Parallel()
+
+	fullDB, err := MakeTestDB(t)
+	require.NoError(t, err, "unable to make test database")
+
+	cdb := fullDB.ChannelStateDB()
+	state := createTestChannel(t, cdb)
+
+	openChannels, err := cdb.FetchOpenChannels(state.IdentityPub)
+	require.NoError(t, err, "unable to fetch open channel")
+	require.Len(t, openChannels, 1, "unexpected number of channels")
+
+	channel := openChannels[0]
+
+	remoteCommit := channel.RemoteCommitment
+	remoteCommit.CommitHeight++
+	remoteCommit.LocalBalance -= 1
+	remoteCommit.RemoteBalance += 1
+
+	commitDiff := &CommitDiff{
+		Commitment: remoteCommit,
+		CommitSig: &lnwire.CommitSig{
+			ChanID:    lnwire.ChannelID(key),
+			CommitSig: wireSig,
+		},
+		LogUpdates:        []LogUpdate{},
+		OpenedCircuitKeys: []models.CircuitKey{},
+		ClosedCircuitKeys: []models.CircuitKey{},
+	}
+
+	err = channel.AppendRemoteCommitChain(commitDiff)
+	require.NoError(t, err, "unable to append remote commit diff")
+
+	err = kvdb.Update(cdb.backend, func(tx kvdb.RwTx) error {
+		chanBucket, err := fetchChanBucketRw(
+			tx, channel.IdentityPub, &channel.FundingOutpoint,
+			channel.ChainHash,
+		)
+		if err != nil {
+			return err
+		}
+
+		return chanBucket.Delete(unsignedAckedUpdatesKey)
+	}, func() {})
+	require.NoError(t, err, "unable to remove unsigned acked updates key")
+
+	remoteUnsignedLocalUpdates := []LogUpdate{
+		{
+			LogIndex: 1,
+			UpdateMsg: &lnwire.UpdateFee{
+				ChanID:   lnwire.ChannelID(key),
+				FeePerKw: 1234,
+			},
+		},
+	}
+
+	oldRemoteCommit := channel.RemoteCommitment
+	fwdPkg := NewFwdPkg(
+		channel.ShortChanID(), oldRemoteCommit.CommitHeight, nil, nil,
+	)
+
+	err = channel.AdvanceCommitChainTail(
+		fwdPkg, remoteUnsignedLocalUpdates, dummyLocalOutputIndex,
+		dummyRemoteOutIndex,
+	)
+	require.NoError(t, err, "unable to advance commit chain tail")
+
+	dbRemoteUnsignedLocalUpdates, err := channel.RemoteUnsignedLocalUpdates()
+	require.NoError(t, err, "unable to fetch remote unsigned local updates")
+	require.Len(t, dbRemoteUnsignedLocalUpdates, 1)
+	require.Equal(
+		t, remoteUnsignedLocalUpdates[0].LogIndex,
+		dbRemoteUnsignedLocalUpdates[0].LogIndex,
+	)
+
+	dbUpdateFee, ok := dbRemoteUnsignedLocalUpdates[0].UpdateMsg.(*lnwire.UpdateFee)
+	require.True(t, ok)
+
+	updateFee, ok := remoteUnsignedLocalUpdates[0].UpdateMsg.(*lnwire.UpdateFee)
+	require.True(t, ok)
+	require.Equal(t, updateFee.ChanID, dbUpdateFee.ChanID)
+	require.Equal(t, updateFee.FeePerKw, dbUpdateFee.FeePerKw)
+
+	err = kvdb.View(cdb.backend, func(tx kvdb.RTx) error {
+		chanBucket, err := fetchChanBucket(
+			tx, channel.IdentityPub, &channel.FundingOutpoint,
+			channel.ChainHash,
+		)
+		if err != nil {
+			return err
+		}
+
+		require.Nil(t, chanBucket.Get(unsignedAckedUpdatesKey))
+
+		return nil
+	}, func() {})
+	require.NoError(t, err)
+}
+
 // TestOpeningChannelTxConfirmation verifies that calling MarkConfirmationHeight
 // correctly updates the confirmed state. It also ensures that calling Refresh
 // on a different OpenChannel updates its in-memory state to reflect the prior

--- a/htlcswitch/link_test.go
+++ b/htlcswitch/link_test.go
@@ -445,9 +445,9 @@ func TestChannelLinkSigThenRev(t *testing.T) {
 	ctx.receiveRevAndAckAliceToBob()
 }
 
-// TestChannelLinkFailDuringRestart tests that the link fails (force-closing
-// the channel) if the commit dance is not completed after sharing the
-// update_fee and one of the peers restarts before completion.
+// TestChannelLinkFailDuringRestart tests that the link does not force-close
+// if the commit dance is interrupted after sharing an update_fee and one of
+// the peers restarts before completion.
 //
 // Specifically, this tests the following scenario:
 //
@@ -457,7 +457,7 @@ func TestChannelLinkSigThenRev(t *testing.T) {
 //	<--revoke_and_ack----
 //	==== restart node ====
 //	<-----commit_sig----
-//	==== force close ====
+//	----revoke_and_ack--->
 func TestChannelLinkFailDuringRestart(t *testing.T) {
 	const chanAmt = btcutil.SatoshiPerBitcoin * 5
 
@@ -519,6 +519,13 @@ func TestChannelLinkFailDuringRestart(t *testing.T) {
 	// Restart Alice so she sends and accepts ChannelReestablish.
 	alice.restart(true, true)
 
+	linkErrors := make(chan LinkFailureError, 1)
+	alice.coreLink.cfg.OnChannelFailure = func(_ lnwire.ChannelID,
+		_ lnwire.ShortChannelID, linkErr LinkFailureError) {
+
+		linkErrors <- linkErr
+	}
+
 	// Restart Bob by re-instantiating NewLightningChannel.
 	bobSigner := harness.bobChannel.Signer
 	signerMock := lnwallet.NewDefaultAuxSignerMock(t)
@@ -539,8 +546,8 @@ func TestChannelLinkFailDuringRestart(t *testing.T) {
 
 	// --channel_reestablish-->
 	// Bob processes Alice's reestablish and re-sends commit_sig.
-	// Alice then force-closes upon receiving the commit_sig, which should
-	// not happen, indicating a bug.
+	// Alice should accept it and respond with revoke_and_ack instead of
+	// force-closing the channel.
 	select {
 	case msg := <-alice.msgs:
 		reestMsg, ok := msg.(*lnwire.ChannelReestablish)
@@ -552,9 +559,19 @@ func TestChannelLinkFailDuringRestart(t *testing.T) {
 		require.NoError(t, err)
 
 		// <-----commit_sig----
-		// ==== force close ====
 		alice.coreLink.HandleChannelUpdate(msgsToReSend[0])
-		time.Sleep(5 * time.Second)
+
+		select {
+		case linkErr := <-linkErrors:
+			t.Fatalf("unexpected link failure: %v", linkErr)
+
+		case msg := <-alice.msgs:
+			_, ok := msg.(*lnwire.RevokeAndAck)
+			require.True(t, ok)
+
+		case <-time.After(5 * time.Second):
+			t.Fatalf("did not receive revoke_and_ack")
+		}
 
 	case <-time.After(5 * time.Second):
 		t.Fatalf("did not receive channel_reestablish message")
@@ -5021,10 +5038,8 @@ func (h *persistentLinkHarness) restartLink(
 		},
 		FetchLastChannelUpdate: mockGetChanUpdateMessage,
 		PreimageCache:          pCache,
-		OnChannelFailure: func(_ lnwire.ChannelID,
-			_ lnwire.ShortChannelID, linkErr LinkFailureError) {
-
-			require.NotEqual(t, linkErr.FailureAction, LinkFailureForceClose)
+		OnChannelFailure: func(lnwire.ChannelID,
+			lnwire.ShortChannelID, LinkFailureError) {
 		},
 		UpdateContractSignals: func(*contractcourt.ContractSignals) error {
 			return nil


### PR DESCRIPTION
## Summary
- localize the `OnChannelFailure` assertion to `TestChannelLinkFailDuringRestart`
- replace the brittle sleep with a deterministic wait for either link failure or `RevokeAndAck`
- update the link test comment to match the fixed post-restart behavior
- preserve the legacy `unsignedAckedUpdatesKey == nil` early return while still persisting `remoteUnsignedLocalUpdatesKey` first
- add a focused `channeldb` regression covering the nil-key upgrade path

## Verification
- `go test ./channeldb -run ''TestOpenChannelPutGetDelete|TestAdvanceCommitChainTailRemoteUnsignedLocalUpdatesWithoutUnsignedAckedKey'' -count=1`
- `go test ./lnwallet -run TestChanSyncUpdateFeeRestartAfterRevoke -count=1`
- `go test ./htlcswitch -run TestChannelLinkFailDuringRestart -count=1`

This is a helper PR for [lightningnetwork/lnd#10622](https://github.com/lightningnetwork/lnd/pull/10622).